### PR TITLE
fix no pango package bug

### DIFF
--- a/textext/asktext.py
+++ b/textext/asktext.py
@@ -96,9 +96,9 @@ def set_monospace_font(text_view):
     :param text_view: A GTK TextView
     """
     try:
-        import pango
-
-        font_desc = pango.FontDescription('monospace 11')
+#         import pango
+        from gi.repository import Pango
+        font_desc = Pango.FontDescription('monospace 16')
         if font_desc:
             text_view.modify_font(font_desc)
     except ImportError:


### PR DESCRIPTION
I think `pango` is not an independent package anymore, I have to import `Pango` from `gi.reposity` which can be installed via `pip install PyGObject`. Then `set_monospace_font`  function works well and you can change the font and fontsize of the texts you input, it's more eye-comfortable.

I‘m sorry that I don't have a MacOS device in hand.
![Jetbrains Mono, 18](https://user-images.githubusercontent.com/59390321/144020661-a20d3ec7-418c-4ba7-a9d9-1ae2fdf6ea86.png)

Short checklist:
- [x] Tested with Inkscape version: Inkscape 1.1.1 (3bf5ae0d25, 2021-09-20, custom)
- [x] Tested on Linux, Distro:  x86_64 Linux 5.4.159-1-MANJARO
- [x] Tested on Windows, Version: Windows 10 21H1
- [ ] Tested on MacOS, Version:  [fill in MacOS version/ name here]
